### PR TITLE
CLV-200 / Dividing messages

### DIFF
--- a/messenger/mainwindow.cpp
+++ b/messenger/mainwindow.cpp
@@ -23,6 +23,8 @@ MainWindow::MainWindow(QMainWindow* parent)
     ui->EnterMessage->setHidden(true);
     ui->SendButton->setHidden(true);
     ui->ScrollBot->setHidden(true);
+    ui->EnterMessage->setMaxLength(255);
+    maxMessageLength = 0;
 }
 
 MainWindow::~MainWindow()
@@ -32,6 +34,7 @@ MainWindow::~MainWindow()
 
 void MainWindow::on_ChatList_itemClicked(QListWidgetItem *item)
 {
+    maxMessageLength = ui->Messages->width() / 6.5 / 2 - 3;
     conversation.clear();
     int index = ui->ChatList->currentRow();
     auto iterator = CurrentUser::getInstance()->getChats().begin();
@@ -216,7 +219,7 @@ void MainWindow::showMessage(QString from, QString message, QString date, QStrin
         ui->Messages->addItem(&conversation.back());
     }
     QListWidgetItem itemFrom(from);
-    QListWidgetItem itemMessage(message);
+    QListWidgetItem itemMessage(setMessageProperties(message));
     QListWidgetItem itemTime(time);
     itemTime.setForeground(Qt::gray);
     if(from == "Me:")
@@ -237,6 +240,29 @@ void MainWindow::showMessage(QString from, QString message, QString date, QStrin
     conversation.push_back(itemTime);
     ui->Messages->addItem(&conversation.back());
     ui->Messages->addItem("");
+}
+
+QString MainWindow::setMessageProperties(QString message)
+{
+    auto words = message.split(' ');
+    QString resultString = "";
+    int currentLength = 0;
+    for(auto &word : words)
+    {
+        if(currentLength + word.length() > maxMessageLength)
+        {
+           resultString += '\n';
+           currentLength = 0;
+        }
+        else
+        {
+            resultString += ' ';
+            currentLength += 1;
+        }
+        resultString += word;
+        currentLength += word.length();
+    }
+    return resultString;
 }
 
 void MainWindow::on_actionSign_out_triggered()

--- a/messenger/mainwindow.h
+++ b/messenger/mainwindow.h
@@ -23,6 +23,7 @@ private:
     void showMessage(QString from, QString message, QString date, QString time);
     void showChats();
     void showSearchingMessage(int count, QString searchingMessage);
+    QString setMessageProperties(QString message);
 
 signals:
     void SignoutButtonClicked();
@@ -55,6 +56,7 @@ private:
     QScrollBar *ScrollBar;
     CurrentChat currentChat;
     std::vector<QListWidgetItem> conversation;
+    int maxMessageLength;
 };
 #endif // MAINWINDOW_H
 


### PR DESCRIPTION
added dividing messages in ui depending on the width of QListWidged
added max size of entering message

tested on Windows10 x64

dev
## JIRA

* [Main JIRA ticket](https://jira.softserve.academy/secure/RapidBoard.jspa?rapidView=id)


## Code reviewers

- [ ] @github_username

### Second Level Review

- [ ] @github_username

## Summary of issue

ToDo

## Summary of change

ToDo

## Testing approach

ToDo

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
